### PR TITLE
Added voila tags for lognorm_ex and widgets_playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # PyPartMC-examples
 Jupyter notebooks exemplifying usage of PyPartMC from Python
 
-#### Jupyter notebooks with examples
+#### Jupyter notebooks with examples 
+Note: only visual examples have corresponding Voila notebooks!
 
 - `hello_world` notebook:    
 [![nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.jupyter.org/github/open-atmos/PyPartMC-examples/blob/main/notebooks/hello_world.ipynb)
@@ -15,10 +16,13 @@ Jupyter notebooks exemplifying usage of PyPartMC from Python
 [![nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.jupyter.org/github/open-atmos/PyPartMC-examples/blob/main/notebooks/widgets_playground.ipynb)
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/open-atmos/PyPartMC-examples/blob/main/notebooks/widgets_playground.ipynb)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/open-atmos/PyPartMC-examples.git/main?urlpath=lab/tree/notebooks/widgets_playground.ipynb)
+[![Voila](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/open-atmos/PyPartMC-examples/HEAD?urlpath=voila%2Frender%2Fnotebooks%2Fwidgets_playground.ipynb)
 - `lognorm_ex` notebook:   
 [![nbviewer](https://raw.githubusercontent.com/jupyter/design/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.jupyter.org/github/open-atmos/PyPartMC-examples/blob/main/notebooks/lognorm_ex.ipynb)
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/open-atmos/PyPartMC-examples/blob/main/notebooks/lognorm_ex.ipynb)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/open-atmos/PyPartMC-examples.git/main?urlpath=lab/tree/notebooks/lognorm_ex.ipynb)
+[![Voila](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/open-atmos/PyPartMC-examples/HEAD?urlpath=voila%2Frender%2Fnotebooks%2Flognorm_ex.ipynb)
+
 #### Reporting issues
 
 Please use [PyPartMC issue tracker](https://github.com/open-atmos/PyPartMC/issues/) for PyPartMC-examples issues as well.


### PR DESCRIPTION
Opted not to add voila tags for hello_world.ipynb and condense.ipynb, since their output seems to be numerical instead of interactive.