### PR TITLE
changed from linear to log grid for diameter to improve smoothness

### DIFF
--- a/notebooks/lognorm_ex.ipynb
+++ b/notebooks/lognorm_ex.ipynb
@@ -150,8 +150,8 @@
     "        )\n",
     "    )\n",
     "    \n",
-    "    diameters = np.linspace(0.1*si.um,10*si.um, 100)\n",
-    "\n",
+    "    diameters = np.logspace(-1,1, 100)* si.um\n",
+    "    \n",
     "    def lognormal(diam, num, geom_mean, geom_stdev):\n",
     "        return diam * (\n",
     "            (num / (np.sqrt(2*np.pi)*diam*np.log(geom_stdev))) *\n",
@@ -213,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.9.13"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
Minor suggestion to change particle diameter sampling to log space to improve the smoothness of plot for modes in the smaller size ranges.