### PR TITLE
Corrections to partmc particles in lognormal example notebook

### DIFF
--- a/notebooks/lognorm_ex.ipynb
+++ b/notebooks/lognorm_ex.ipynb
@@ -26,16 +26,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "225ca5ad",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#TODOS: why is 2 needed, why PartMC gives wet diameters less than dry for low kappas"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "7c55b23d",
    "metadata": {},
    "outputs": [],

--- a/notebooks/lognorm_ex.ipynb
+++ b/notebooks/lognorm_ex.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "id": "a19b8c92",
    "metadata": {},
    "outputs": [],
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "id": "225ca5ad",
    "metadata": {},
    "outputs": [],
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "id": "7c55b23d",
    "metadata": {},
    "outputs": [],
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 5,
    "id": "4dcc3eae",
    "metadata": {},
    "outputs": [],
@@ -68,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 6,
    "id": "9eec9565",
    "metadata": {},
    "outputs": [],
@@ -119,7 +119,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 7,
    "id": "d5b424ab",
    "metadata": {},
    "outputs": [],
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 8,
    "id": "54097605",
    "metadata": {},
    "outputs": [],
@@ -146,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 9,
    "id": "9af4df17",
    "metadata": {},
    "outputs": [],
@@ -172,21 +172,21 @@
     "    \n",
     "    dry_volumes = (np.pi / 6) * dry_diameters**3\n",
     "    aero_particles = [\n",
-    "        ppmc.AeroParticle(aero_data, np.array([0, 2])*volume) for volume in dry_volumes\n",
+    "        ppmc.AeroParticle(aero_data, np.array([0, 1])*volume) for volume in dry_volumes\n",
     "    ]\n",
     "\n",
     "    for aero_particle in aero_particles:\n",
     "        ppmc.condense_equilib_particle(env_state, aero_data, aero_particle)\n",
     "\n",
-    "    wet_volumes = [particle.volumes[0] for particle in aero_particles]\n",
+    "    wet_volumes = [np.sum(particle.volumes) for particle in aero_particles]\n",
     "    wet_diameters = ((6 / np.pi) * np.asarray(wet_volumes))**(1/3)\n",
-    "    \n",
+    "\n",
     "    return wet_diameters"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 10,
    "id": "4d9881b4",
    "metadata": {},
    "outputs": [],
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 11,
    "id": "ee131ad8",
    "metadata": {},
    "outputs": [],
@@ -221,14 +221,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 12,
    "id": "56fd1c71",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "84cfd879c546449688ab7d2f21f60e04",
+       "model_id": "80290b2ae19f446aa0dfdb44847c50c9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -242,7 +242,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4a42a54191504d4c962bce22dc07a3f3",
+       "model_id": "82069f9818c947b293cb35f23bb754d4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -256,7 +256,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b20de981ebd6444eb2c8e2a00fe1ffef",
+       "model_id": "d45d5cb620514766857859dd324fb132",
        "version_major": 2,
        "version_minor": 0
       },
@@ -270,7 +270,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9d92898ae5a8411bb0213740632c7dc3",
+       "model_id": "7b44cc3968254e7fb05f771a8a7df56a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -284,7 +284,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2d8f05c2210c4789986c9dffed3f76d9",
+       "model_id": "edb9e589b14744f6800a0cf2240e9abd",
        "version_major": 2,
        "version_minor": 0
       },
@@ -298,7 +298,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7035c1e0b6444606a9789e341dacca43",
+       "model_id": "cfd1e386a6504de7ac65a5e0be5ed7e0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -312,7 +312,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "74d4c6bb69ee40d589dc9eae4f2161df",
+       "model_id": "259891ecb2674b35b288344f34e6c474",
        "version_major": 2,
        "version_minor": 0
       },
@@ -326,7 +326,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "da26f835012146578d2abbdc09dbc1b1",
+       "model_id": "c6cd87b57b484f34ad11b813be9eb8f4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -340,7 +340,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "12f5397423c44b2d9c64604b74f3dea7",
+       "model_id": "14b4168c256942bb8c25187ebf160cef",
        "version_major": 2,
        "version_minor": 0
       },
@@ -354,7 +354,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "70e1cdd655bd4060add842a1e751a00d",
+       "model_id": "ef8b501289794042a699c71e77ffba61",
        "version_major": 2,
        "version_minor": 0
       },
@@ -368,7 +368,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1967be2d11164e3b8f2245dcd02735b0",
+       "model_id": "dc9aab627de64526911e58a3c5a1f522",
        "version_major": 2,
        "version_minor": 0
       },
@@ -382,7 +382,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "00cc5089d2f0420b9bb165e3ebfcb4f7",
+       "model_id": "4640486fd63c4bfd98fa8cd948a51208",
        "version_major": 2,
        "version_minor": 0
       },
@@ -462,6 +462,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0527a2af",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f44c647f-0eb7-479d-ad33-bac8c4f0db44",
    "metadata": {},
    "outputs": [],
    "source": []


### PR DESCRIPTION
Looking at this notebook and some strange behavior, I noted the following aspects that I think need to be changed although correct me if I'm wrong as I'm not very familiar with what this notebook is doing.

The volumes of the particles was set incorrectly - particles were actually twice the volume that we would expet. Now if we compute the total diameters, set the total volumes and back out the total volumes while disabling the condensation step (or setting the RH to 0), we end up with the same answer as the diameters should be unchanged.

I think the wet volume of the particles was being calculated incorrect and I've replaced it with a sum of the two species. Before it was just water - which is why I think that low kappa values had particle sizes that were smaller than the dry as the water content was just so small. When water content is large, the dry mass isn't that important if excluded.